### PR TITLE
Adds grammar lesson for demonstrative adjectives, future, and stress pronouns

### DIFF
--- a/app/(tabs)/grammar.tsx
+++ b/app/(tabs)/grammar.tsx
@@ -1,4 +1,6 @@
+import AntDesign from '@expo/vector-icons/AntDesign';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
+import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { Link } from 'expo-router';
 import React from 'react';
@@ -16,6 +18,20 @@ export default function grammer() {
           <Text style={[styles.boxtext, grammarStyle.boxPadding]}>Pronominal Verb</Text>
          </View>
         </Link>
+         
+        <Link href="/grammar/demonstrative_adjective" style={styles.box}>
+         <View >
+          <MaterialCommunityIcons name="vector-point" size={35} color="black" />
+          <Text style={[styles.boxtext, grammarStyle.boxPadding]}>Demonstrative Adjective</Text>
+         </View>
+        </Link>
+
+        <Link href="/grammar/stress_pronoun" style={styles.box}>
+         <View >
+          <FontAwesome5 name="hand-point-down" size={35} color="black" />
+          <Text style={[styles.boxtext, grammarStyle.boxPadding]}>Stress Pronouns</Text>
+         </View>
+        </Link>
 
         <Link href="/grammar/conjugation" style={styles.box}>
          <View >
@@ -23,7 +39,14 @@ export default function grammer() {
           <Text style={[styles.boxtext, grammarStyle.boxPadding]}>Verb Conjugation</Text>
          </View>
         </Link>
-        
+
+        <Link href="/grammar/future" style={styles.box}>
+         <View >
+          <AntDesign name="arrowright" size={40} color="black" />
+          <Text style={[styles.boxtext, grammarStyle.boxPadding]}>Future Proche (Near Future)</Text>
+         </View>
+        </Link>
+     
       </ScrollView>
     </View>
   )

--- a/app/grammar/demonstrative_adjective/index.tsx
+++ b/app/grammar/demonstrative_adjective/index.tsx
@@ -1,0 +1,178 @@
+import { Stack } from 'expo-router';
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+
+export default function DemonstrativeAdjectivesExplanationExpo() {
+  return (
+    <ScrollView contentContainerStyle={styles.scrollViewContent}>
+      <Stack.Screen options={{ title: 'Demonstrative Adjective' }} />
+      
+      <Text style={styles.paragraph}>
+        Demonstrative adjectives in French, known as <Text style={styles.bold}>les adjectifs démonstratifs</Text>, are used to point out specific nouns. They are equivalent to "this," "that," "these," and "those" in English. Like all adjectives in French, they must agree in gender and number with the noun they modify.
+      </Text>
+
+      <Text style={styles.subHeading}>Forms of Demonstrative Adjectives:</Text>
+      <Text style={styles.subHeadingDescription}>
+        There are four main forms, which change based on the gender and number of the noun they precede:
+      </Text>
+
+      {/* Demonstrative Adjectives Table */}
+      <View style={styles.tableContainer}>
+        {/* Table Header Row */}
+        <View style={styles.tableRow}>
+          <Text style={[styles.tableCell, styles.tableHeader]}> </Text>
+          <Text style={[styles.tableCell, styles.tableHeader]}>Masculine Singular</Text>
+          <Text style={[styles.tableCell, styles.tableHeader]}>Feminine Singular</Text>
+          <Text style={[styles.tableCell, styles.tableHeader]}>Plural (Masculine & Feminine)</Text>
+        </View>
+        {/* Table Row 1 */}
+        <View style={styles.tableRow}>
+          <Text style={[styles.tableCell, styles.tableRowLabel]}>Before a consonant</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>ce</Text> (this/that)</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>cette</Text> (this/that)</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>ces</Text> (these/those)</Text>
+        </View>
+        {/* Table Row 2 */}
+        <View style={styles.tableRow}>
+          <Text style={[styles.tableCell, styles.tableRowLabel]}>Before a vowel or silent 'h'</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>cet</Text> (this/that)</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>cette</Text> (this/that)</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>ces</Text> (these/those)</Text>
+        </View>
+      </View>
+
+      <Text style={styles.subHeading}>Key Points and Usage:</Text>
+
+      {/* Usage Section */}
+      <View style={styles.bulletPointContainer}>
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>1. Agreement in Gender and Number:</Text>
+          {'\n'}  • <Text style={styles.bold}>Ce:</Text> Used before masculine singular nouns starting with a consonant.
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: <Text style={styles.bold}>Ce</Text> livre (this/that book)</Text>
+          {'\n'}  • <Text style={styles.bold}>Cet:</Text> Used before masculine singular nouns starting with a vowel (<Text style={styles.italic}>a, e, i, o, u</Text>) or a silent 'h' to avoid a hiatus.
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: <Text style={styles.bold}>Cet</Text> arbre (this/that tree)</Text>
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: <Text style={styles.bold}>Cet</Text> homme (this/that man)</Text>
+          {'\n'}  • <Text style={styles.bold}>Cette:</Text> Used before all feminine singular nouns.
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: <Text style={styles.bold}>Cette</Text> maison (this/that house)</Text>
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: <Text style={styles.bold}>Cette</Text> amie (this/that friend - feminine)</Text>
+          {'\n'}  • <Text style={styles.bold}>Ces:</Text> Used before all plural nouns (masculine and feminine).
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: <Text style={styles.bold}>Ces</Text> voitures (these/those cars)</Text>
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: <Text style={styles.bold}>Ces</Text> enfants (these/those children)</Text>
+        </Text>
+
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>2. Placement:</Text>
+          {'\n'}  Demonstrative adjectives are always placed directly <Text style={styles.italic}>before</Text> the noun they modify. They replace an article (like <Text style={styles.italic}>le, la, les, un, une, des</Text>).
+          {'\n    '}<Text style={styles.exampleTextItalic}>Incorrect: <Text style={styles.italic}>Le ce livre</Text> (The this book)</Text>
+          {'\n    '}<Text style={styles.exampleTextItalic}>Correct: <Text style={styles.bold}>Ce</Text> livre (This book)</Text>
+        </Text>
+
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>3. Distinguishing "This/These" vs. "That/Those":</Text>
+          {'\n'}  French demonstrative adjectives do not inherently distinguish between "this/these" (near) and "that/those" (far).
+          {'\n'}  To make the distinction explicit, add suffixes to the noun: <Text style={styles.italic}>-ci</Text> (for "here" / nearby) or <Text style={styles.italic}>-là</Text> (for "there" / farther away).
+          {'\n'}  Structure: <Text style={styles.italic}>demonstrative adjective + noun + -ci / -là</Text>
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: <Text style={styles.bold}>Cette</Text> chaise<Text style={styles.bold}>-ci</Text> (this chair here)</Text>
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: <Text style={styles.bold}>Ces</Text> livres<Text style={styles.bold}>-là</Text> (those books there)</Text>
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: Je préfère <Text style={styles.bold}>ce</Text> vin<Text style={styles.bold}>-ci</Text>. (I prefer this wine here.)</Text>
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: Tu aimes <Text style={styles.bold}>cet</Text> ordinateur<Text style={styles.bold}>-là</Text> ? (Do you like that computer there?)</Text>
+        </Text>
+
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>4. Used to Point Out:</Text>
+          {'\n'}  Their primary function is to point out or specify a particular person, animal, or thing from a group.
+          {'\n    '}<Text style={styles.exampleTextItalic}>Example: Regarde <Text style={styles.bold}>cette</Text> fleur ! (Look at this flower!)</Text>
+        </Text>
+      </View>
+
+      <Text style={styles.paragraph}>
+        Mastering demonstrative adjectives is fundamental for precise communication in French, allowing you to clearly indicate which noun you are referring to.
+      </Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollViewContent: {
+    flexGrow: 1,
+    paddingVertical: 20,
+    paddingHorizontal: 15,
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: '#333',
+    textAlign: 'center',
+  },
+  subHeading: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginTop: 25,
+    marginBottom: 10,
+    color: '#555',
+  },
+  subHeadingDescription: {
+    fontSize: 16,
+    marginBottom: 10,
+    color: '#444',
+  },
+  paragraph: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginBottom: 15,
+    color: '#444',
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
+  italic: {
+    fontStyle: 'italic',
+  },
+  tableContainer: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    marginBottom: 20,
+    backgroundColor: '#fff',
+    overflow: 'hidden', 
+  },
+  tableRow: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+  tableCell: {
+    flex: 1,
+    padding: 10,
+    fontSize: 15,
+    textAlign: 'center',
+  },
+  tableHeader: {
+    backgroundColor: '#e0f7fa',
+    fontWeight: 'bold',
+    color: '#00796b',
+  },
+  tableRowLabel: {
+    textAlign: 'left',
+    paddingLeft: 15,
+    fontWeight: '600',
+    color: '#555',
+    flex: 1.5, 
+  },
+  bulletPointContainer: {
+    marginBottom: 15,
+  },
+  bulletPoint: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginBottom: 15,
+    color: '#444',
+  },
+  exampleTextItalic: {
+    fontStyle: 'italic',
+    color: '#2e7d32',
+    marginTop: 5,
+    marginLeft: 20,
+  },
+});

--- a/app/grammar/future/index.tsx
+++ b/app/grammar/future/index.tsx
@@ -1,0 +1,148 @@
+import { Stack } from 'expo-router';
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+
+export default function FuturProcheExplanationExpo() {
+  return (
+    <ScrollView contentContainerStyle={styles.scrollViewContent}>
+        <Stack.Screen options={{ title: 'Futur Proche' }} />
+     
+      <Text style={styles.paragraph}>
+        The "futur proche" in French translates to the "near future" or "immediate future" in English. It's used to talk about events that are going to happen very soon.
+      </Text>
+
+      <Text style={styles.subHeading}>Formation:</Text>
+      <Text style={styles.formula}>
+        Subject + conjugated form of "aller" (to go) + infinitive verb
+      </Text>
+
+      <Text style={styles.subHeading}>"Aller" Conjugation (Present Tense):</Text>
+      <View style={styles.conjugationContainer}>
+        <Text style={styles.conjugationText}>je <Text style={styles.bold}>vais</Text> (I go)</Text>
+        <Text style={styles.conjugationText}>tu <Text style={styles.bold}>vas</Text> (you go - informal singular)</Text>
+        <Text style={styles.conjugationText}>il/elle/on <Text style={styles.bold}>va</Text> (he/she/one goes)</Text>
+        <Text style={styles.conjugationText}>nous <Text style={styles.bold}>allons</Text> (we go)</Text>
+        <Text style={styles.conjugationText}>vous <Text style={styles.bold}>allez</Text> (you go - formal singular or plural)</Text>
+        <Text style={styles.conjugationText}>ils/elles <Text style={styles.bold}>vont</Text> (they go)</Text>
+      </View>
+
+      <Text style={styles.paragraph}>
+        <Text style={styles.bold}>Infinitive verb:</Text> This is the base form of the verb (e.g., manger - to eat, parler - to speak, faire - to do/make).
+      </Text>
+
+      <Text style={styles.subHeading}>Examples:</Text>
+      <View style={styles.exampleContainer}>
+        <Text style={styles.exampleText}>• <Text style={styles.bold}>Je vais manger.</Text> (I am going to eat.)</Text>
+        <Text style={styles.exampleText}>• <Text style={styles.bold}>Tu vas étudier.</Text> (You are going to study.)</Text>
+        <Text style={styles.exampleText}>• <Text style={styles.bold}>Il va pleuvoir.</Text> (It is going to rain.)</Text>
+        <Text style={styles.exampleText}>• <Text style={styles.bold}>Nous allons partir.</Text> (We are going to leave.)</Text>
+        <Text style={styles.exampleText}>• <Text style={styles.bold}>Vous allez regarder un film.</Text> (You are going to watch a movie.)</Text>
+        <Text style={styles.exampleText}>• <Text style={styles.bold}>Elles vont dormir.</Text> (They are going to sleep.)</Text>
+      </View>
+
+      <Text style={styles.subHeading}>When to use the futur proche:</Text>
+      <View style={styles.bulletPointContainer}>
+        <Text style={styles.bulletPoint}>
+          • <Text style={styles.bold}>Actions happening very soon:</Text> As the name suggests, it's for things that are about to occur.
+          {'\n  '}  - <Text style={styles.exampleTextItalic}>Je vais sortir dans cinq minutes. (I'm going to go out in five minutes.)</Text>
+        </Text>
+        <Text style={styles.bulletPoint}>
+          • <Text style={styles.bold}>Planned actions in the near future:</Text> Even if not immediate, it can be used for definite plans.
+          {'\n  '}  - <Text style={styles.exampleTextItalic}>Nous allons voyager en France cet été. (We are going to travel to France this summer.)</Text>
+        </Text>
+        <Text style={styles.bulletPoint}>
+          • <Text style={styles.bold}>Indicating a strong intention:</Text>
+          {'\n  '}  - <Text style={styles.exampleTextItalic}>Je vais t'aider. (I am going to help you.)</Text>
+        </Text>
+      </View>
+
+      <Text style={styles.paragraph}>
+        It's a very common and useful tense in everyday French conversation!
+      </Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+ scrollViewContent: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: 20,
+    paddingHorizontal: 15,
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: '#333',
+    textAlign: 'center',
+  },
+  subHeading: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginTop: 25,
+    marginBottom: 10,
+    color: '#555',
+  },
+  paragraph: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginBottom: 15,
+    color: '#444',
+  },
+  formula: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    fontStyle: 'italic',
+    backgroundColor: '#e0f7fa',
+    padding: 10,
+    borderRadius: 8,
+    marginBottom: 15,
+    textAlign: 'center',
+    color: '#00796b',
+  },
+  conjugationContainer: {
+    backgroundColor: '#fff',
+    padding: 15,
+    borderRadius: 8,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+    elevation: 3,
+    marginBottom: 15,
+  },
+  conjugationText: {
+    fontSize: 16,
+    marginBottom: 5,
+    color: '#666',
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
+  exampleContainer: {
+    backgroundColor: '#e8f5e9',
+    padding: 15,
+    borderRadius: 8,
+    marginBottom: 15,
+  },
+  exampleText: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginBottom: 5,
+    color: '#2e7d32',
+  },
+  exampleTextItalic: {
+    fontStyle: 'italic',
+    color: '#4caf50',
+  },
+  bulletPointContainer: {
+    marginBottom: 15,
+  },
+  bulletPoint: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginBottom: 10,
+    color: '#444',
+  },
+});

--- a/app/grammar/stress_pronoun/index.tsx
+++ b/app/grammar/stress_pronoun/index.tsx
@@ -1,0 +1,222 @@
+import { Stack } from 'expo-router';
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+
+export default function StressPronounsExplanationExpo() {
+  return (
+    <ScrollView contentContainerStyle={styles.scrollViewContent}>
+      <Stack.Screen options={{ title: 'Stress Pronouns' }} />
+
+      <Text style={styles.paragraph}>
+        Stress pronouns in French, also known as <Text style={styles.bold}>pronoms toniques</Text>, <Text style={styles.bold}>disjunctive pronouns</Text>, or <Text style={styles.bold}>emphatic pronouns</Text>, are used for emphasis and in specific grammatical contexts where regular subject or object pronouns cannot be used. They generally refer to people or animals, not objects or ideas.
+      </Text>
+
+      <Text style={styles.subHeading}>List of Stress Pronouns:</Text>
+      <View style={styles.pronounTable}>
+        {/* Table Header */}
+        <View style={styles.tableRowHeader}>
+          <Text style={[styles.tableCell, styles.tableHeaderCell]}>Subject Pronoun</Text>
+          <Text style={[styles.tableCell, styles.tableHeaderCell]}>Stress Pronoun</Text>
+          <Text style={[styles.tableCell, styles.tableHeaderCell]}>English Equivalent</Text>
+        </View>
+        {/* Table Rows */}
+        <View style={styles.tableRow}>
+          <Text style={styles.tableCell}>je</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>moi</Text></Text>
+          <Text style={styles.tableCell}>me</Text>
+        </View>
+        <View style={styles.tableRow}>
+          <Text style={styles.tableCell}>tu</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>toi</Text></Text>
+          <Text style={styles.tableCell}>you (singular, informal)</Text>
+        </View>
+        <View style={styles.tableRow}>
+          <Text style={styles.tableCell}>il</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>lui</Text></Text>
+          <Text style={styles.tableCell}>him</Text>
+        </View>
+        <View style={styles.tableRow}>
+          <Text style={styles.tableCell}>elle</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>elle</Text></Text>
+          <Text style={styles.tableCell}>her</Text>
+        </View>
+        <View style={styles.tableRow}>
+          <Text style={styles.tableCell}>on</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>soi</Text></Text>
+          <Text style={styles.tableCell}>oneself, one, everyone</Text>
+        </View>
+        <View style={styles.tableRow}>
+          <Text style={styles.tableCell}>nous</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>nous</Text></Text>
+          <Text style={styles.tableCell}>us</Text>
+        </View>
+        <View style={styles.tableRow}>
+          <Text style={styles.tableCell}>vous</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>vous</Text></Text>
+          <Text style={styles.tableCell}>you (plural, or formal singular)</Text>
+        </View>
+        <View style={styles.tableRow}>
+          <Text style={styles.tableCell}>ils</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>eux</Text></Text>
+          <Text style={styles.tableCell}>them (masculine or mixed group)</Text>
+        </View>
+        <View style={styles.tableRow}>
+          <Text style={styles.tableCell}>elles</Text>
+          <Text style={styles.tableCell}><Text style={styles.bold}>elles</Text></Text>
+          <Text style={styles.tableCell}>them (feminine)</Text>
+        </View>
+      </View>
+      <Text style={styles.noteParagraph}>
+        (Note: <Text style={styles.bold}>elle</Text>, <Text style={styles.bold}>nous</Text>, and <Text style={styles.bold}>vous</Text> are the same for both subject and stress pronouns.)
+      </Text>
+
+      <Text style={styles.subHeading}>When to use Stress Pronouns:</Text>
+
+      <View style={styles.bulletPointContainer}>
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>1. For Emphasis (Accent Tonique):</Text>
+          {'\n'}  To stress who is performing an action or who something refers to.
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: <Text style={styles.bold}>Moi</Text>, je suis toujours à l'heure. (Me, I'm always on time.)</Text>
+        </Text>
+
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>2. After Prepositions:</Text>
+          {'\n'}  Stress pronouns always follow prepositions (e.g., <Text style={styles.italic}>à, de, chez, avec, pour, sans, entre, contre</Text>).
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: C'est pour <Text style={styles.bold}>moi</Text> ? (Is this for me?)</Text>
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: Je veux aller avec <Text style={styles.bold}>toi</Text>. (I want to go with you.)</Text>
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: Nous pensons à <Text style={styles.bold}>eux</Text>. (We're thinking about them.)</Text>
+        </Text>
+
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>3. In Short Answers or Single-Word Responses:</Text>
+          {'\n'}  When answering a question without repeating the verb.
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: Qui veut un café ? - <Text style={styles.bold}>Moi</Text> ! (Who wants a coffee? - Me!)</Text>
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: Qui est à la porte ? - <Text style={styles.bold}>Lui</Text> ! (Who's at the door? - Him!)</Text>
+        </Text>
+
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>4. After "C'est" and "Ce sont":</Text>
+          {'\n'}  To emphasize who "it is" or "it is they."
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: C'est <Text style={styles.bold}>moi</Text> qui l'ai fait. (It's me who did it.)</Text>
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: Ce sont <Text style={styles.bold}>elles</Text> qui ont gagné. (It's them who won.)</Text>
+        </Text>
+
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>5. In Compound Subjects or Objects (with Conjunctions):</Text>
+          {'\n'}  When two pronouns or a pronoun and a noun are connected by conjunctions like <Text style={styles.italic}>et</Text> (and), <Text style={styles.italic}>ou</Text> (or), <Text style={styles.italic}>ni</Text> (neither/nor).
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: <Text style={styles.bold}>Elle et moi</Text> étudions le français. (She and I are studying French.)</Text>
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: Ni <Text style={styles.bold}>toi ni lui</Text> ne peuvent venir. (Neither you nor he can come.)</Text>
+        </Text>
+
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>6. In Comparisons (after <Text style={styles.italic}>que</Text>):</Text>
+          {'\n'}  Used after comparison words like <Text style={styles.italic}>plus...que, moins...que, aussi...que</Text>.
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: Je suis plus grand que <Text style={styles.bold}>lui</Text>. (I am taller than him.)</Text>
+        </Text>
+
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>7. With <Text style={styles.italic}>-même(s)</Text> for Added Emphasis:</Text>
+          {'\n'}  To express "myself," "yourself," "himself," etc.
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: J'ai fait le gâteau <Text style={styles.bold}>moi-même</Text>. (I made the cake myself.)</Text>
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: Ils ont construit la maison <Text style={styles.bold}>eux-mêmes</Text>. (They built the house themselves.)</Text>
+        </Text>
+
+        <Text style={styles.bulletPoint}>
+          <Text style={styles.bold}>8. In Affirmative Commands (Imperative Mood):</Text>
+          {'\n'}  <Text style={styles.italic}>Moi</Text> and <Text style={styles.bold}>toi</Text> replace direct/indirect object pronouns <Text style={styles.italic}>me</Text> and <Text style={styles.italic}>te</Text> in affirmative commands.
+          {'\n  '}<Text style={styles.exampleTextItalic}>• Example: Donne-<Text style={styles.bold}>moi</Text> le livre. (Give me the book.)</Text>
+          {'\n  '}<Text style={styles.exampleTextItalic}>(Compare to <Text style={styles.italic}>Ne me donne pas le livre</Text> - Don't give me the book, where <Text style={styles.italic}>me</Text> is used for negative commands).</Text>
+        </Text>
+      </View>
+
+      <Text style={styles.paragraph}>
+        Understanding stress pronouns is crucial for speaking French naturally and correctly, as they are used extensively in everyday conversation.
+      </Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollViewContent: {
+    flexGrow: 1,
+    paddingVertical: 20,
+    paddingHorizontal: 15,
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: '#333',
+    textAlign: 'center',
+  },
+  subHeading: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginTop: 25,
+    marginBottom: 10,
+    color: '#555',
+  },
+  paragraph: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginBottom: 15,
+    color: '#444',
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
+  italic: {
+    fontStyle: 'italic',
+  },
+  pronounTable: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    marginBottom: 15,
+    backgroundColor: '#fff',
+    overflow: 'hidden', 
+  },
+  tableRowHeader: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: '#ddd',
+    backgroundColor: '#e0f7fa',
+  },
+  tableRow: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+  tableCell: {
+    flex: 1,
+    padding: 10,
+    fontSize: 15,
+    textAlign: 'center',
+  },
+  tableHeaderCell: {
+    fontWeight: 'bold',
+    color: '#00796b',
+  },
+  noteParagraph: {
+    fontSize: 14,
+    fontStyle: 'italic',
+    color: '#666',
+    marginBottom: 15,
+    textAlign: 'center',
+  },
+  bulletPointContainer: {
+    marginBottom: 15,
+  },
+  bulletPoint: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginBottom: 15,
+    color: '#444',
+  },
+  exampleTextItalic: {
+    fontStyle: 'italic',
+    color: '#2e7d32',
+    marginTop: 5,
+    marginLeft: 20,
+  },
+});


### PR DESCRIPTION
Added new screens and navigation links for Demonstrative Adjectives, Futur Proche (Near Future), and Stress Pronouns in the grammar section. Each new screen provides detailed explanations and examples for the respective grammar topic. Updated the main grammar tab to include links and icons for the new lessons.